### PR TITLE
martini/DX-71: Clean Up Unit Tests

### DIFF
--- a/lib/src/test/java/com/metaplex/lib/MetaplexTestUtils.kt
+++ b/lib/src/test/java/com/metaplex/lib/MetaplexTestUtils.kt
@@ -1,0 +1,20 @@
+package com.metaplex.lib
+
+import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
+import com.metaplex.lib.drivers.storage.MemoryStorageDriver
+import com.metaplex.lib.drivers.storage.StorageDriver
+import com.metaplex.lib.solana.SolanaConnectionDriver
+import com.solana.core.PublicKey
+import com.solana.networking.RPCEndpoint
+
+object MetaplexTestUtils {
+
+    val TEST_ACCOUNT_PUBLICKEY =
+        PublicKey("CN87nZuhnFdz74S9zn3bxCcd5ZxW55nwvgAv5C2Tz3K7")
+}
+
+fun MetaplexTestUtils.generateMetaplexInstance(storageDriver: StorageDriver = MemoryStorageDriver()): Metaplex {
+    val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
+    val solanaIdentityDriver = ReadOnlyIdentityDriver(TEST_ACCOUNT_PUBLICKEY, solanaConnection.solanaRPC)
+    return Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
+}

--- a/lib/src/test/java/com/metaplex/lib/MetaplexTestUtils.kt
+++ b/lib/src/test/java/com/metaplex/lib/MetaplexTestUtils.kt
@@ -8,13 +8,13 @@ import com.solana.core.PublicKey
 import com.solana.networking.RPCEndpoint
 
 object MetaplexTestUtils {
-
-    val TEST_ACCOUNT_PUBLICKEY =
-        PublicKey("CN87nZuhnFdz74S9zn3bxCcd5ZxW55nwvgAv5C2Tz3K7")
+    val TEST_ACCOUNT_PUBLICKEY = PublicKey(SolanaTestData.TEST_ACCOUNT_PUBLICKEY_STRING)
 }
 
-fun MetaplexTestUtils.generateMetaplexInstance(storageDriver: StorageDriver = MemoryStorageDriver()): Metaplex {
+fun MetaplexTestUtils.generateMetaplexInstance(accountPublicKey: PublicKey = TEST_ACCOUNT_PUBLICKEY,
+                                               storageDriver: StorageDriver = MemoryStorageDriver())
+: Metaplex {
     val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-    val solanaIdentityDriver = ReadOnlyIdentityDriver(TEST_ACCOUNT_PUBLICKEY, solanaConnection.solanaRPC)
+    val solanaIdentityDriver = ReadOnlyIdentityDriver(accountPublicKey, solanaConnection.solanaRPC)
     return Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
 }

--- a/lib/src/test/java/com/metaplex/lib/MetaplexTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/MetaplexTests.kt
@@ -1,63 +1,55 @@
 package com.metaplex.lib
 
-import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
-import com.metaplex.lib.drivers.storage.MemoryStorageDriver
-import com.metaplex.lib.drivers.storage.StorageDriver
-import com.metaplex.lib.solana.SolanaConnectionDriver
-import com.solana.core.PublicKey
+import com.metaplex.lib.MetaplexTestUtils.TEST_ACCOUNT_PUBLICKEY
 import com.solana.models.buffer.AccountInfo
 import com.solana.models.buffer.BufferInfo
-import com.solana.networking.RPCEndpoint
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-val TEST_PUBLICKEY = PublicKey("CN87nZuhnFdz74S9zn3bxCcd5ZxW55nwvgAv5C2Tz3K7")
-
 class MetaplexTests {
-    
-    lateinit var metaplex: Metaplex
 
-    @Before
-    fun setUp() {
-        val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-        val solanaIdentityDriver = ReadOnlyIdentityDriver(TEST_PUBLICKEY, solanaConnection.solanaRPC)
-        val storageDriver = MemoryStorageDriver()
-        this.metaplex = Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
-    }
+    val metaplex: Metaplex get() = MetaplexTestUtils.generateMetaplexInstance()
     
     @Test
-    fun testSetUpMetaplex() {
-        val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-        val solanaIdentityDriver = ReadOnlyIdentityDriver(TEST_PUBLICKEY, solanaConnection.solanaRPC)
-        val storageDriver = MemoryStorageDriver()
-        val metaplex = Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
+    fun testMetaplexSetUpReturnsValidInstance() {
         Assert.assertNotNull(metaplex)
     }
 
     @Test
-    fun testGetAccountInfo() {
+    fun testGetAccountInfoReturnsNonNullBufferForValidAccount() {
+        // given
+        val accountKey = TEST_ACCOUNT_PUBLICKEY
+        var bufferInfo: BufferInfo<AccountInfo>? = null
+
+        // when
         val lock = CountDownLatch(1)
-        var bufferInfo: Result<BufferInfo<AccountInfo>>? = null
-        metaplex.getAccountInfo(TEST_PUBLICKEY, AccountInfo::class.java) {
-            bufferInfo = it
+        metaplex.getAccountInfo(accountKey, AccountInfo::class.java) {
+            bufferInfo = it.getOrNull()
             lock.countDown()
         }
         lock.await(2000, TimeUnit.MILLISECONDS)
-        Assert.assertNotNull(bufferInfo!!.getOrThrow())
+
+        // then
+        Assert.assertNotNull(bufferInfo)
     }
 
     @Test
-    fun testGetMultipleAccounts() {
+    fun testGetMultipleAccountsReturnsNonNullBuffer() {
+        // given
+        val accountKeys = listOf(TEST_ACCOUNT_PUBLICKEY)
+        var bufferInfo: List<BufferInfo<AccountInfo>?>? = null
+
+        // when
         val lock = CountDownLatch(1)
-        var bufferInfo: Result<List<BufferInfo<AccountInfo>?>>? = null
-        metaplex.getMultipleAccountsInfo(listOf(TEST_PUBLICKEY), AccountInfo::class.java) {
-            bufferInfo = it
+        metaplex.getMultipleAccountsInfo(accountKeys, AccountInfo::class.java) {
+            bufferInfo = it.getOrNull()
             lock.countDown()
         }
         lock.await(2000, TimeUnit.MILLISECONDS)
-        Assert.assertNotNull(bufferInfo!!.getOrThrow())
+
+        // then
+        Assert.assertNotNull(bufferInfo)
     }
 }

--- a/lib/src/test/java/com/metaplex/lib/SolanaTestData.kt
+++ b/lib/src/test/java/com/metaplex/lib/SolanaTestData.kt
@@ -1,0 +1,46 @@
+package com.metaplex.lib
+
+// it might make sense to move this to a shared test director later
+typealias AccountKeyMnemonicPair = Pair<List<String>, String>
+val AccountKeyMnemonicPair.mnemonic get() = first
+val AccountKeyMnemonicPair.publicKey get() = second
+
+object SolanaTestData {
+
+    //region TEST DATA
+    // We could eventually move this data to a json file so
+    // this test account data could be easily swapped out
+    val TEST_ACCOUNT_PUBLICKEY_STRING = "CN87nZuhnFdz74S9zn3bxCcd5ZxW55nwvgAv5C2Tz3K7"
+
+    val TEST_ACCOUNT_MNEMONIC_PAIR = AccountKeyMnemonicPair(listOf(
+        "across", "start", "ancient", "solid",
+        "bid", "sentence", "visit", "old",
+        "have", "hobby", "magic", "bomb",
+        "boring", "grunt", "rule", "extra",
+        "place", "strong", "myth", "episode",
+        "dinner", "thrive", "wave", "decide"
+    ), "FJyTK5ggCyWaZoJoQ9YAeRokNZtHbN4UwzeSWa2HxNyy")
+
+    // TODO: We need a way to generate test models so we can easily inject test data
+//    val TEST_DATA_NFT_1 = mapOf(
+//        "name" to "DeGod #5116",
+//        "mintKey" to "7A1R6HLKVEnu74kCM7qb59TpmJGyUX8f5t7p3FCrFTVR",
+//        "collectionKey" to "6XxjKYFbcndh2gDcsUrmZgVEsoDxXMnfsaGY6fpTJzNr",
+//        "editionNonce" to 254,
+//        "creators" to listOf(
+//            mapOf("address" to "9MynErYQ5Qi6obp4YwwdoDmXkZ1hYVtPUqYmJJ3rZ9Kn")
+//        )
+//    )
+//
+//    val TEST_DATA_NFT_2 = mapOf(
+//        "name" to "Degen Ape #6125",
+//        "mintKey" to "GU6wXYYyCiXA2KMBd1e1eXttpK1mzjRPjK6rA2QD1fN2",
+//        "collectionKey" to "DSwfRF1jhhu6HpSuzaig1G19kzP73PfLZBPLofkw6fLD",
+//        "editionNonce" to 255,
+//        "creators" to listOf(
+//            mapOf("address" to "9BKWqDHfHZh9j39xakYVMdr6hXmCLHH5VfCpeq2idU9L")
+//        )
+//    )
+    //endregion
+}
+

--- a/lib/src/test/java/com/metaplex/lib/drivers/identity/KeypairIdentityDriverTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/drivers/identity/KeypairIdentityDriverTests.kt
@@ -1,6 +1,9 @@
 package com.metaplex.lib.drivers.identity
 
+import com.metaplex.lib.SolanaTestData
 import com.metaplex.lib.drivers.indenty.KeypairIdentityDriver
+import com.metaplex.lib.mnemonic
+import com.metaplex.lib.publicKey
 import com.metaplex.lib.solana.SolanaConnectionDriver
 import com.solana.core.Account
 import com.solana.core.DerivationPath
@@ -8,49 +11,50 @@ import com.solana.core.Transaction
 import com.solana.networking.RPCEndpoint
 import com.solana.programs.SystemProgram
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
-val mnemonic = listOf("across", "start", "ancient", "solid", "bid", "sentence", "visit", "old", "have", "hobby", "magic", "bomb", "boring", "grunt", "rule", "extra", "place", "strong", "myth", "episode", "dinner", "thrive", "wave", "decide")
-
 class KeypairIdentityDriverTests {
 
-    private val account = Account.fromMnemonic(mnemonic, "", DerivationPath.BIP44_M_44H_501H_0H_OH)
-    private val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-    lateinit var keypairIdentityDriver: KeypairIdentityDriver
-
-    @Before
-    fun setUp() {
-        keypairIdentityDriver = KeypairIdentityDriver(solanaConnection.solanaRPC, account)
-    }
-
     @Test
-    fun testSetUpKeypairIdentityDriver() {
+    fun testSetUpKeypairIdentityDriverFromMnemonic() {
+        // given
+        val expectedPublicKey = SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.publicKey
         val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-        val keypairIdentityDriver = KeypairIdentityDriver(solanaConnection.solanaRPC, Account.fromMnemonic(mnemonic, "", DerivationPath.BIP44_M_44H_501H_0H_OH))
-        Assert.assertEquals(keypairIdentityDriver.publicKey.toBase58(), "FJyTK5ggCyWaZoJoQ9YAeRokNZtHbN4UwzeSWa2HxNyy")
+
+        // when
+        val keypairIdentityDriver = KeypairIdentityDriver(solanaConnection.solanaRPC,
+            Account.fromMnemonic(SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.mnemonic, "", DerivationPath.BIP44_M_44H_501H_0H_OH))
+
+        //then
+        Assert.assertEquals(expectedPublicKey, keypairIdentityDriver.publicKey.toBase58())
     }
 
     @Test
-    fun testSendTransactionInstruction() {
+    fun testSignTransactionReturnsTrxHash() {
+        // given
+        val account = Account.fromMnemonic(SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.mnemonic, "", DerivationPath.BIP44_M_44H_501H_0H_OH)
         val expectedSignedTransaction = "AaHQ/obYLnD6GUFqxDKiiNkw2NYsLt+NZHa8ALB64uM0wpADNVQ5eWhzW38FcxfthDz6zXsJao58y5/fFovSoAABAAEC1J5StK6hI4+ERBMKkBUsHeIzegza3Eb/t7dwtSG4Q9QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJrdSfHQAfBFYiaNQeEg3d9YB3F537Ex4K5dG79qBe0rAQECAAAMAgAAAOgDAAAAAAAA"
-
-        val lock = CountDownLatch(1)
-        var result: Result<Transaction>? = null
         val instruction = SystemProgram.transfer(account.publicKey, account.publicKey, 1000)
-        val transaction = Transaction()
-        transaction.addInstruction(instruction)
-        transaction.setRecentBlockHash("BRXVgGhoUSYEoDUipLK7yGgvGvqp5TnRh6mNRMmubsmU")
-        keypairIdentityDriver.signTransaction(transaction){
-            result = it
+        val transaction = Transaction().apply {
+            addInstruction(instruction)
+            setRecentBlockHash("BRXVgGhoUSYEoDUipLK7yGgvGvqp5TnRh6mNRMmubsmU")
         }
 
+        // when
+        var result: Transaction? = null
+        val keypairIdentityDriver = KeypairIdentityDriver(
+            SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana).solanaRPC, account)
+
+        val lock = CountDownLatch(1)
+        keypairIdentityDriver.signTransaction(transaction){
+            result = it.getOrNull()
+        }
         lock.await(2000, TimeUnit.MILLISECONDS)
-        val signedTransaction = result!!.getOrThrow()
-        Assert.assertNotNull(signedTransaction)
-        val base64Trx: String = java.util.Base64.getEncoder().encodeToString(signedTransaction.serialize())
-        Assert.assertEquals(base64Trx, expectedSignedTransaction)
+
+        // then
+        val base64Trx: String = java.util.Base64.getEncoder().encodeToString(result?.serialize())
+        Assert.assertEquals(expectedSignedTransaction, base64Trx)
     }
 }

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/models/NFTTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/models/NFTTests.kt
@@ -1,33 +1,23 @@
 package com.metaplex.lib.modules.nfts.models
 
 import com.metaplex.lib.Metaplex
-import com.metaplex.lib.TEST_PUBLICKEY
-import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
+import com.metaplex.lib.MetaplexTestUtils
 import com.metaplex.lib.drivers.storage.OkHttpSharedStorageDriver
+import com.metaplex.lib.generateMetaplexInstance
 import com.metaplex.lib.modules.nfts.operations.FindNftByMintOnChainOperationHandler
 import com.metaplex.lib.modules.nfts.operations.FindNftByMintOperation
 import com.metaplex.lib.programs.token_metadata.accounts.MetaplexTokenStandard
 import com.metaplex.lib.shared.ResultWithCustomError
-import com.metaplex.lib.solana.SolanaConnectionDriver
 import com.solana.core.PublicKey
-import com.solana.networking.RPCEndpoint
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class NFTTests {
-    lateinit var metaplex: Metaplex
 
-    @Before
-    fun setUp() {
-        val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-        val solanaIdentityDriver =
-            ReadOnlyIdentityDriver(TEST_PUBLICKEY, solanaConnection.solanaRPC)
-        val storageDriver = OkHttpSharedStorageDriver()
-        this.metaplex = Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
-    }
+    val metaplex: Metaplex get() =
+        MetaplexTestUtils.generateMetaplexInstance(OkHttpSharedStorageDriver())
 
     @Test
     fun testsNFTonChain() {

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/models/NFTTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/models/NFTTests.kt
@@ -8,6 +8,7 @@ import com.metaplex.lib.modules.nfts.operations.FindNftByMintOnChainOperationHan
 import com.metaplex.lib.modules.nfts.operations.FindNftByMintOperation
 import com.metaplex.lib.programs.token_metadata.accounts.MetaplexTokenStandard
 import com.metaplex.lib.shared.ResultWithCustomError
+import com.metaplex.lib.shared.getOrDefault
 import com.solana.core.PublicKey
 import org.junit.Assert
 import org.junit.Test
@@ -17,64 +18,89 @@ import java.util.concurrent.TimeUnit
 class NFTTests {
 
     val metaplex: Metaplex get() =
-        MetaplexTestUtils.generateMetaplexInstance(OkHttpSharedStorageDriver())
+        MetaplexTestUtils.generateMetaplexInstance(storageDriver = OkHttpSharedStorageDriver())
 
     @Test
     fun testsNFTonChain() {
+        // given
+        val mintOperationPublicKey = PublicKey("7A1R6HLKVEnu74kCM7qb59TpmJGyUX8f5t7p3FCrFTVR")
+        val expectedNftName = "DeGod #5116"
+        val expectedCreatorAddress = "9MynErYQ5Qi6obp4YwwdoDmXkZ1hYVtPUqYmJJ3rZ9Kn"
+        val expectedCollectionKey = "6XxjKYFbcndh2gDcsUrmZgVEsoDxXMnfsaGY6fpTJzNr"
+        val expectedEditionNonce = 254
+        val expectedTokenStandard = MetaplexTokenStandard.NonFungible
+
+        // when
         var nft: NFT? = null
         val lock = CountDownLatch(1)
         val operation = FindNftByMintOnChainOperationHandler(metaplex)
         operation.handle(
             FindNftByMintOperation.pure(
-                ResultWithCustomError.success(PublicKey("7A1R6HLKVEnu74kCM7qb59TpmJGyUX8f5t7p3FCrFTVR"))
+                ResultWithCustomError.success(mintOperationPublicKey)
             )
         )
             .run {
-                nft = it.getOrThrows()
+                nft = it.getOrDefault(null)
                 lock.countDown()
             }
         lock.await(20000, TimeUnit.MILLISECONDS)
-        Assert.assertNotNull(nft)
 
-        Assert.assertEquals(nft!!.name, "DeGod #5116")
-        Assert.assertEquals(nft!!.creators.first().address.toBase58(), "9MynErYQ5Qi6obp4YwwdoDmXkZ1hYVtPUqYmJJ3rZ9Kn")
-        Assert.assertEquals(nft!!.primarySaleHappened, true)
-        Assert.assertEquals(nft!!.isMutable, true)
-        Assert.assertEquals(nft!!.editionNonce, 254)
-        Assert.assertEquals(nft!!.tokenStandard, MetaplexTokenStandard.NonFungible)
-        Assert.assertNotNull(nft!!.collection)
-        Assert.assertEquals(nft!!.collection!!.key.toBase58(), "6XxjKYFbcndh2gDcsUrmZgVEsoDxXMnfsaGY6fpTJzNr")
-
+        // then
+        Assert.assertNotNull(nft) // safe to force unwrap after this check
+        Assert.assertEquals(expectedNftName, nft!!.name)
+        Assert.assertEquals(expectedCreatorAddress, nft!!.creators.first().address.toBase58())
+        Assert.assertEquals(expectedCollectionKey, nft!!.collection?.key?.toBase58())
+        Assert.assertEquals(expectedEditionNonce, nft!!.editionNonce)
+        Assert.assertEquals(expectedTokenStandard, nft!!.tokenStandard)
+        Assert.assertTrue(nft!!.primarySaleHappened)
+        Assert.assertTrue(nft!!.isMutable)
     }
 
     @Test
     fun testsNFTonChain2() {
+        // given
+        val mintOperationPublicKey = PublicKey("GU6wXYYyCiXA2KMBd1e1eXttpK1mzjRPjK6rA2QD1fN2")
+        val expectedNftName = "Degen Ape #6125"
+        val expectedCreatorAddress = "9BKWqDHfHZh9j39xakYVMdr6hXmCLHH5VfCpeq2idU9L"
+        val expectedCollectionKey = "DSwfRF1jhhu6HpSuzaig1G19kzP73PfLZBPLofkw6fLD"
+        val expectedEditionNonce = 255
+        val expectedTokenStandard = MetaplexTokenStandard.NonFungible
+
+        // when
         var nft: NFT? = null
         val lock = CountDownLatch(1)
         val operation = FindNftByMintOnChainOperationHandler(metaplex)
         operation.handle(
             FindNftByMintOperation.pure(
-                ResultWithCustomError.success(PublicKey("GU6wXYYyCiXA2KMBd1e1eXttpK1mzjRPjK6rA2QD1fN2"))
+                ResultWithCustomError.success(mintOperationPublicKey)
             )
         )
             .run {
-                nft = it.getOrThrows()
+                nft = it.getOrDefault(null)
                 lock.countDown()
             }
         lock.await(20000, TimeUnit.MILLISECONDS)
-        Assert.assertNotNull(nft)
-        Assert.assertEquals(nft!!.name, "Degen Ape #6125")
-        Assert.assertEquals(nft!!.creators.first().address.toBase58(), "9BKWqDHfHZh9j39xakYVMdr6hXmCLHH5VfCpeq2idU9L")
-        Assert.assertEquals(nft!!.primarySaleHappened, true)
-        Assert.assertEquals(nft!!.isMutable, false)
-        Assert.assertEquals(nft!!.editionNonce, 255)
-        Assert.assertEquals(nft!!.tokenStandard, MetaplexTokenStandard.NonFungible)
-        Assert.assertNotNull(nft!!.collection)
-        Assert.assertEquals(nft!!.collection?.key!!.toBase58(), "DSwfRF1jhhu6HpSuzaig1G19kzP73PfLZBPLofkw6fLD")
+
+        // then
+        Assert.assertNotNull(nft) // safe to force unwrap after this check
+        Assert.assertEquals(expectedNftName, nft!!.name)
+        Assert.assertEquals(expectedCreatorAddress, nft!!.creators.first().address.toBase58())
+        Assert.assertEquals(expectedCollectionKey, nft!!.collection?.key?.toBase58())
+        Assert.assertEquals(expectedEditionNonce, nft!!.editionNonce)
+        Assert.assertEquals(expectedTokenStandard, nft!!.tokenStandard)
+        Assert.assertTrue(nft!!.primarySaleHappened)
+        Assert.assertFalse(nft!!.isMutable)
     }
 
     @Test
     fun testsNFTMetadata() {
+        // given
+        val expectedName = "Aurorian #628"
+        val expectedSymbol = "AUROR"
+        val expectedSellerFeeBasisPoints = 500.0
+        val expectedCreatorAddress = "8Kag8CqNdCX55s4A5W4iraS71h6mv6uTHqsJbexdrrZm"
+
+        // when
         var metadata: JsonMetadata? = null
         var nft: NFT? = null
         val lock = CountDownLatch(1)
@@ -88,15 +114,17 @@ class NFTTests {
                 }
             }
         lock.await(20000, TimeUnit.MILLISECONDS)
-        Assert.assertNotNull(metadata)
-        Assert.assertEquals("Aurorian #628", metadata!!.name)
-        Assert.assertEquals("AUROR", metadata!!.symbol)
-        Assert.assertEquals(500.0, metadata!!.seller_fee_basis_points)
-        val value = (metadata!!.attributes!![10].value as Value.number).value
-        Assert.assertTrue(1.0 == value)
-        Assert.assertEquals(
-            "8Kag8CqNdCX55s4A5W4iraS71h6mv6uTHqsJbexdrrZm",
-            metadata!!.properties!!.creators!!.first().address
+
+        // then
+        Assert.assertNotNull(metadata)  // safe to force unwrap after this check
+        Assert.assertEquals(expectedName, metadata!!.name)
+        Assert.assertEquals(expectedSymbol, metadata!!.symbol)
+        Assert.assertEquals(expectedSellerFeeBasisPoints, metadata!!.seller_fee_basis_points)
+        Assert.assertNotNull(
+            metadata!!.properties?.creators?.find { it.address == expectedCreatorAddress }
         )
+
+        val value = (metadata!!.attributes!![10].value as Value.number).value
+        Assert.assertEquals(1.0, value, 0.0)
     }
 }

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByMintListOnChainOperationHandlerTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByMintListOnChainOperationHandlerTests.kt
@@ -4,8 +4,8 @@ import com.metaplex.lib.Metaplex
 import com.metaplex.lib.MetaplexTestUtils
 import com.metaplex.lib.generateMetaplexInstance
 import com.metaplex.lib.modules.nfts.models.NFT
-import com.metaplex.lib.shared.OperationError
 import com.metaplex.lib.shared.ResultWithCustomError
+import com.metaplex.lib.shared.getOrDefault
 import com.solana.core.PublicKey
 import org.junit.Assert
 import org.junit.Test
@@ -18,63 +18,65 @@ class FindNftsByMintListOnChainOperationHandlerTests {
 
     @Test
     fun testFindNftsByMintListOnChainOperation() {
+        // given
+        val expectedMintKeys = listOf(
+            "HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn",
+            "B3n4QMZWCfsTZxC6bgJh9YGWFjESmExSYp8NGfJ8DQvF"
+        )
+        val expectedNftNames = listOf("Aurorian #628", "Degen Ape #2031")
+        val expectedNftCount = expectedMintKeys.size
+
+        // when
         val lock = CountDownLatch(1)
-        var result: ResultWithCustomError<List<NFT?>, OperationError>? = null
+        var result = listOf<NFT?>()
         val operation = FindNftsByMintListOnChainOperationHandler(metaplex)
         operation.handle(
             FindNftsByMintListOperation.pure(
-                ResultWithCustomError.success(
-                    listOf(
-                        PublicKey("HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn"),
-                        PublicKey("B3n4QMZWCfsTZxC6bgJh9YGWFjESmExSYp8NGfJ8DQvF")
-                    )
-                )
+                ResultWithCustomError.success( expectedMintKeys.map { PublicKey(it) })
             )
         ).run {
-            result = it
+            result = it.getOrDefault(listOf())
             lock.countDown()
         }
         lock.await(2000, TimeUnit.MILLISECONDS)
 
-        val nft = result!!.getOrThrows().first()
-        Assert.assertNotNull(nft)
-
-        Assert.assertEquals("Aurorian #628", nft!!.metadataAccount.data.name,)
-        Assert.assertEquals("HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn", nft.metadataAccount.mint.toBase58())
-
-        val nft2 = result!!.getOrThrows()[1]!!
-        Assert.assertNotNull(nft2)
-
-        Assert.assertEquals("Degen Ape #2031", nft2!!.metadataAccount.data.name,)
-        Assert.assertEquals("B3n4QMZWCfsTZxC6bgJh9YGWFjESmExSYp8NGfJ8DQvF", nft2.metadataAccount.mint.toBase58())
+        // then
+        Assert.assertEquals(expectedNftCount, result.size)
+        result.forEachIndexed { i, nft ->
+            Assert.assertNotNull(nft)
+            Assert.assertEquals(expectedNftNames[i], nft!!.metadataAccount.data.name)
+            Assert.assertEquals(expectedMintKeys[i], nft.metadataAccount.mint.toBase58())
+        }
     }
     @Test
     fun testFindNftsByMintListOnChainOperation_OneNull() {
+        // given
+        val expectedNftName = "Aurorian #628"
+        val expectedMintKey = "HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn"
+
+        // when
+        var result: List<NFT?> = listOf()
         val lock = CountDownLatch(1)
-        var result: ResultWithCustomError<List<NFT?>, OperationError>? = null
         val operation = FindNftsByMintListOnChainOperationHandler(metaplex)
         operation.handle(
             FindNftsByMintListOperation.pure(
                 ResultWithCustomError.success(
-                    listOf(
-                        PublicKey("HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn"),
-                        PublicKey("")
-                    )
+                    listOf(PublicKey(expectedMintKey), PublicKey(""))
                 )
             )
         ).run {
-            result = it
+            result = it.getOrDefault(listOf())
             lock.countDown()
         }
         lock.await(2000, TimeUnit.MILLISECONDS)
 
-        val nft = result!!.getOrThrows().first()
+        // then
+        val nft = result.first()
         Assert.assertNotNull(nft)
+        Assert.assertEquals(expectedNftName, nft!!.metadataAccount.data.name)
+        Assert.assertEquals(expectedMintKey, nft.metadataAccount.mint.toBase58())
 
-        Assert.assertEquals("Aurorian #628", nft!!.metadataAccount.data.name)
-        Assert.assertEquals("HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn", nft.metadataAccount.mint.toBase58())
-
-        val nft2 = result!!.getOrThrows()[1]
+        val nft2 = result[1]
         Assert.assertNull(nft2)
     }
 }

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByMintListOnChainOperationHandlerTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByMintListOnChainOperationHandlerTests.kt
@@ -1,33 +1,20 @@
 package com.metaplex.lib.modules.nfts.operations
 
 import com.metaplex.lib.Metaplex
-import com.metaplex.lib.TEST_PUBLICKEY
-import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
-import com.metaplex.lib.drivers.storage.MemoryStorageDriver
+import com.metaplex.lib.MetaplexTestUtils
+import com.metaplex.lib.generateMetaplexInstance
 import com.metaplex.lib.modules.nfts.models.NFT
 import com.metaplex.lib.shared.OperationError
 import com.metaplex.lib.shared.ResultWithCustomError
-import com.metaplex.lib.solana.SolanaConnectionDriver
 import com.solana.core.PublicKey
-import com.solana.networking.RPCEndpoint
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class FindNftsByMintListOnChainOperationHandlerTests {
 
-    lateinit var metaplex: Metaplex
-
-    @Before
-    fun setUp() {
-        val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-        val solanaIdentityDriver =
-            ReadOnlyIdentityDriver(TEST_PUBLICKEY, solanaConnection.solanaRPC)
-        val storageDriver = MemoryStorageDriver()
-        this.metaplex = Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
-    }
+    val metaplex: Metaplex get() = MetaplexTestUtils.generateMetaplexInstance()
 
     @Test
     fun testFindNftsByMintListOnChainOperation() {

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByOwnerOnChainOperationHandlerTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByOwnerOnChainOperationHandlerTests.kt
@@ -1,50 +1,46 @@
 package com.metaplex.lib.modules.nfts.operations
 
 import com.metaplex.lib.Metaplex
-import com.metaplex.lib.TEST_PUBLICKEY
-import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
-import com.metaplex.lib.drivers.storage.MemoryStorageDriver
+import com.metaplex.lib.MetaplexTestUtils
+import com.metaplex.lib.MetaplexTestUtils.TEST_ACCOUNT_PUBLICKEY
+import com.metaplex.lib.generateMetaplexInstance
 import com.metaplex.lib.modules.nfts.models.NFT
-import com.metaplex.lib.shared.OperationError
 import com.metaplex.lib.shared.ResultWithCustomError
-import com.metaplex.lib.solana.SolanaConnectionDriver
-import com.solana.core.PublicKey
-import com.solana.networking.RPCEndpoint
+import com.metaplex.lib.shared.getOrDefault
 import org.junit.Assert
-import org.junit.Before
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 class FindNftsByOwnerOnChainOperationHandlerTests {
 
-    lateinit var metaplex: Metaplex
-
-    @Before
-    fun setUp() {
-        val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-        val solanaIdentityDriver = ReadOnlyIdentityDriver(TEST_PUBLICKEY, solanaConnection.solanaRPC)
-        val storageDriver = MemoryStorageDriver()
-        this.metaplex = Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
-    }
+    val metaplex: Metaplex get() = MetaplexTestUtils.generateMetaplexInstance()
 
     @Test
     fun testFindNftsByOwnerOnChainOperation() {
-        val lock = CountDownLatch(1)
-        var result: ResultWithCustomError<List<NFT?>, OperationError>? = null
+        // given
+        val accountKey = TEST_ACCOUNT_PUBLICKEY
+        val expectedNftMintKey = "71PdnsexRQG92ZcSpEV8nn5XFqPzfK5j86yUWRF5NLyp"
+        val expectedNftAuthKey = "AVgijgTG4WKDycFwYhqioMreXJpz14no8dbE8EF5roZV"
         val operation = FindNftsByOwnerOnChainOperationHandler(metaplex)
+        var resultList: List<NFT?>? = null
+
+        //when
+        val lock = CountDownLatch(1)
         operation.handle(
-            FindNftsByOwnerOperation.pure(
-                ResultWithCustomError.success(PublicKey("CN87nZuhnFdz74S9zn3bxCcd5ZxW55nwvgAv5C2Tz3K7"))
-            )
+            FindNftsByOwnerOperation.pure(ResultWithCustomError.success(accountKey))
         ).run {
-            result = it
+            resultList = it.getOrDefault(null)
             lock.countDown()
         }
         lock.await(2000, TimeUnit.MILLISECONDS)
-        val nft = result!!.getOrThrows()
-        Assert.assertNotNull(nft)
-        val anNFT = nft.find { it?.metadataAccount?.mint?.toBase58() == "71PdnsexRQG92ZcSpEV8nn5XFqPzfK5j86yUWRF5NLyp" }
-        Assert.assertEquals("AVgijgTG4WKDycFwYhqioMreXJpz14no8dbE8EF5roZV", anNFT!!.metadataAccount.update_authority.toBase58())
+
+        val actualNftAuthKey = resultList?.find {
+            it?.metadataAccount?.mint?.toBase58() == expectedNftMintKey
+        }?.metadataAccount?.update_authority?.toBase58()
+
+        // then
+        Assert.assertNotNull(resultList)
+        Assert.assertEquals(expectedNftAuthKey, actualNftAuthKey)
     }
 }

--- a/lib/src/test/java/com/metaplex/lib/programs/token_metadata/accounts/MasterEditionAccountTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/programs/token_metadata/accounts/MasterEditionAccountTests.kt
@@ -10,6 +10,7 @@ import org.junit.Test
 class MasterEditionAccountTests {
     @Test
     fun testFindAddress() {
+        // given
         val mintKey = PublicKey("HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn")
         val pdaSeeds = listOf(
             MetaplexContstants.METADATA_NAME.toByteArray(),
@@ -18,11 +19,13 @@ class MasterEditionAccountTests {
             MetaplexContstants.METADATA_EDITION.toByteArray(),
         )
 
+        // when
         val expectedPdaAddress = PublicKey.findProgramAddress(
             pdaSeeds,
             PublicKey(MetaplexContstants.METADATA_ACCOUNT_PUBKEY)
         )
 
+        // then
         val pda = MasterEditionAccount.pda(mintKey).getOrThrows()
         Assert.assertEquals(expectedPdaAddress.address.toBase58(), pda.toBase58())
     }

--- a/lib/src/test/java/com/metaplex/lib/programs/token_metadata/accounts/MetadataAccountTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/programs/token_metadata/accounts/MetadataAccountTests.kt
@@ -17,14 +17,15 @@ class MetadataAccountTests {
             mintKey.toByteArray()
         )
 
-        // when
         val expectedPdaAddress = PublicKey.findProgramAddress(
             pdaSeeds,
             PublicKey(MetaplexContstants.METADATA_ACCOUNT_PUBKEY)
         )
 
-        // then
+        // when
         val pda = MetadataAccount.pda(mintKey).getOrThrows()
+
+        // then
         Assert.assertEquals(expectedPdaAddress.address.toBase58(), pda.toBase58())
     }
 }

--- a/lib/src/test/java/com/metaplex/lib/programs/token_metadata/accounts/MetadataAccountTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/programs/token_metadata/accounts/MetadataAccountTests.kt
@@ -9,6 +9,7 @@ import org.junit.Test
 class MetadataAccountTests {
     @Test
     fun testFindAddress() {
+        // given
         val mintKey = PublicKey("HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn")
         val pdaSeeds = listOf(
             MetaplexContstants.METADATA_NAME.toByteArray(),
@@ -16,11 +17,13 @@ class MetadataAccountTests {
             mintKey.toByteArray()
         )
 
+        // when
         val expectedPdaAddress = PublicKey.findProgramAddress(
             pdaSeeds,
             PublicKey(MetaplexContstants.METADATA_ACCOUNT_PUBKEY)
         )
 
+        // then
         val pda = MetadataAccount.pda(mintKey).getOrThrows()
         Assert.assertEquals(expectedPdaAddress.address.toBase58(), pda.toBase58())
     }


### PR DESCRIPTION
## Description
- Refactor existing Unit Tests to make them more readable and prepare for further refactor
- https://linear.app/metaplex/issue/DX-71

## Work Completed
- refactored all tests to use given/when/then format, with expected values extracted (easier to maintain)
- moved redundant code to `MetaplexTestUtil` abstraction 
- moved some testing data to dedicated `SolanaTestData` abstraction 
  - NOTE: this is a preliminary step, I would like to move towards a full test data/model injection architecture

## Testing
- 14/14 Unit Tests passing