### PR TITLE
DX-139: Switch to/add support for Jitpack 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,7 +21,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Run Tests
-        env:
-          GITHUB_ACTOR: ${{ secrets.GRADLE_GITHUB_ACTOR }}
-          GITHUB_TOKEN: ${{ secrets.GRADLE_GITHUB_TOKEN }}
         run: ./gradlew test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Gradle Lint
-        env:
-          GITHUB_ACTOR: ${{ secrets.GRADLE_GITHUB_ACTOR }}
-          GITHUB_TOKEN: ${{ secrets.GRADLE_GITHUB_TOKEN }}
         run: ./gradlew lint
       - name: Generate Annotations
         uses: yutailang0119/action-android-lint@v3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please check the [Sample App](https://github.com/metaplex-foundation/metaplex-an
 
 The library is now is available through [JitPack.io](https://jitpack.io/#metaplex-foundation/metaplex-android)
 
-First, add the Add the JitPack repository to your build:
+First, add the JitPack repository to your build:
 
 ```
 repositories {
@@ -21,7 +21,7 @@ repositories {
 }
 ```
 
-Then add the dependency to the build.gradle file for your app/module:
+Then add the dependency to the 'build.gradle' file for your app/module:
 
 ```
 dependencies {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please check the [Sample App](https://github.com/metaplex-foundation/metaplex-an
 
 ## Installation
 
-### JitPack [![Release](https://jitpack.io/v/User/Repo.svg)](https://jitpack.io/#User/Repo)
+### JitPack [![Release](https://jitpack.io/v/metaplex-foundation/metaplex-android.svg)](https://jitpack.io/#metaplex-foundation/metaplex-android)
 
 The library is now is available through [JitPack.io](https://jitpack.io/#metaplex-foundation/metaplex-android)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ dependencies {
 
 ### GitHub Package
 
-You can also ad the dependency directly from GitHUb. I recommend using the github recommended way to load Artifacts. First get a Github Token from your [account settings](https://github.com/settings/tokens).
+You can also add the dependency directly from GitHUb. I recommend using the github recommended way to load Artifacts. First get a Github Token from your [account settings](https://github.com/settings/tokens).
 
 
 Inside settings.gradle add a maven repository:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,31 @@ Please check the [Sample App](https://github.com/metaplex-foundation/metaplex-an
 
 ## Installation
 
-I recomend using the github recomended way to load Artifacts. First get a Github Token from your [account settings](https://github.com/settings/tokens).
+### JitPack [![Release](https://jitpack.io/v/User/Repo.svg)](https://jitpack.io/#User/Repo)
+
+The library is now is available through [JitPack.io](https://jitpack.io/#metaplex-foundation/metaplex-android)
+
+First, add the Add the JitPack repository to your build:
+
+```
+repositories {
+	...
+	maven { url 'https://jitpack.io' }
+}
+```
+
+Then add the dependency to the build.gradle file for your app/module:
+
+```
+dependencies {
+	...
+	implementation 'com.github.metaplex-foundation:metaplex-android:{version}'
+}
+```
+
+### GitHub Package
+
+You can also ad the dependency directly from GitHUb. I recommend using the github recommended way to load Artifacts. First get a Github Token from your [account settings](https://github.com/settings/tokens).
 
 
 Inside settings.gradle add a maven repository:

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -34,16 +34,22 @@ android {
 }
 
 dependencies {
-    implementation 'com.solana:solana:1.1.5'
+
+    testImplementation 'junit:junit:4.+'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.1'
+
+    // SolanaKT
+    implementation 'com.github.ajamaica.Solanakt:rxsolana:1.1.5'
+
+    // Moshi
     implementation "com.squareup.moshi:moshi:1.12.0"
     kapt 'com.squareup.moshi:moshi-kotlin-codegen:1.12.0'
-    testImplementation 'junit:junit:4.+'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }
 
 //region PUBLISHING

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -11,8 +11,8 @@ android {
     defaultConfig {
         minSdk 21
         targetSdk 31
-        versionCode 2
-        versionName "1.1.0"
+        versionCode 3
+        versionName "1.1.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -36,7 +36,7 @@ android {
 
 dependencies {
     implementation project(path: ':lib')
-    implementation 'com.solana:solana:1.1.5'
+    implementation 'com.github.ajamaica.Solanakt:rxsolana:1.1.5'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,14 +3,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        maven {
-            name = "GitHubPackages"
-            url = "https://maven.pkg.github.com/ajamaica/SolanaKT"
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
+        maven { url 'https://jitpack.io' }
     }
 }
 rootProject.name = "Metaplex"


### PR DESCRIPTION
## Description
- We have external requests to move our mobile SDK(s) from GitHub Packages to Jitpack.io so that our library can be added as a dependency without needing to authenticate with GitHub. 
- https://linear.app/metaplex/issue/dx-139

## Work Completed
- Switched to Jitpack dependency for SolanaKT: `'com.github.ajamaica.Solanakt:rxsolana:1.1.5'`
- removed GitHub Packages repository form project settings as its no longer needed 

## API Changes
- A list of any changes made to the public API
- remove this section if no changes to the public API

## Testing
### Local Build
- Launched the sample app on emulator to verify that gradle builds successfully and sample app continues to work as expected

### Additional Testing Required 
- after this PR has been merged and we have published a new v1.1.1 release, we should check [jitpack](https://jitpack.io/#metaplex-foundation/metaplex-android/) to verify that the build is succeeding and verify that the new jitpack dependency works in a new app 