### PR TITLE
Testing Refactor

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,3 +19,5 @@ android.useAndroidX=true
 android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
+
+testing.rpc.url="http://127.0.0.1:8899"

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -17,6 +17,9 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        def testingRpcUrl = project.getProperties().get("testing.rpc.url").toString().replace('"', '')
+        buildConfigField 'String', 'RPC_URL', "\"$testingRpcUrl\""
     }
 
     buildTypes {

--- a/lib/src/test/java/com/metaplex/lib/MetaplexTestUtils.kt
+++ b/lib/src/test/java/com/metaplex/lib/MetaplexTestUtils.kt
@@ -1,20 +1,41 @@
 package com.metaplex.lib
 
+import com.metaplex.lib.drivers.indenty.KeypairIdentityDriver
 import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
+import com.metaplex.lib.drivers.rpc.JdkRpcDriver
+import com.metaplex.lib.drivers.solana.Commitment
+import com.metaplex.lib.drivers.solana.Connection
 import com.metaplex.lib.drivers.solana.SolanaConnectionDriver
+import com.metaplex.lib.drivers.solana.TransactionOptions
 import com.metaplex.lib.drivers.storage.MemoryStorageDriver
 import com.metaplex.lib.drivers.storage.StorageDriver
+import com.solana.core.Account
 import com.solana.core.PublicKey
 import com.solana.networking.RPCEndpoint
+import java.net.URL
 
 object MetaplexTestUtils {
+    const val RPC_URL = BuildConfig.RPC_URL
+
+    val DEFAULT_TRANSACTION_OPTIONS = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true)
+
     val TEST_ACCOUNT_PUBLICKEY = PublicKey(SolanaTestData.TEST_ACCOUNT_PUBLICKEY_STRING)
 }
 
-fun MetaplexTestUtils.generateMetaplexInstance(accountPublicKey: PublicKey = TEST_ACCOUNT_PUBLICKEY,
-                                               storageDriver: StorageDriver = MemoryStorageDriver())
-: Metaplex {
+fun MetaplexTestUtils.generateConnectionDriver(
+    rpcURL: URL = URL(RPC_URL), txOptions: TransactionOptions = DEFAULT_TRANSACTION_OPTIONS
+) = SolanaConnectionDriver(JdkRpcDriver(rpcURL), txOptions)
+
+fun MetaplexTestUtils.generateMetaplexInstance(
+    account: Account = Account(), connectionDriver: Connection = generateConnectionDriver(),
+    storageDriver: StorageDriver = MemoryStorageDriver()
+): Metaplex {
+    val identityDriver = KeypairIdentityDriver(account, connectionDriver)
+    return Metaplex(connectionDriver, identityDriver, storageDriver)
+}
+
+val MetaplexTestUtils.readOnlyMainnetMetaplexInstance: Metaplex get() {
     val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
-    val solanaIdentityDriver = ReadOnlyIdentityDriver(accountPublicKey, solanaConnection)
-    return Metaplex(solanaConnection, solanaIdentityDriver, storageDriver)
+    val solanaIdentityDriver = ReadOnlyIdentityDriver(TEST_ACCOUNT_PUBLICKEY, solanaConnection)
+    return Metaplex(solanaConnection, solanaIdentityDriver, MemoryStorageDriver())
 }

--- a/lib/src/test/java/com/metaplex/lib/MetaplexTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/MetaplexTests.kt
@@ -3,6 +3,7 @@ package com.metaplex.lib
 import com.metaplex.lib.MetaplexTestUtils.TEST_ACCOUNT_PUBLICKEY
 import com.solana.models.buffer.AccountInfo
 import com.solana.models.buffer.BufferInfo
+import com.solana.networking.RPCEndpoint
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.CountDownLatch
@@ -10,8 +11,7 @@ import java.util.concurrent.TimeUnit
 
 class MetaplexTests {
 
-    val metaplex: Metaplex get() = MetaplexTestUtils.generateMetaplexInstance()
-    
+    val metaplex: Metaplex get() = MetaplexTestUtils.readOnlyMainnetMetaplexInstance
     @Test
     fun testMetaplexSetUpReturnsValidInstance() {
         Assert.assertNotNull(metaplex)

--- a/lib/src/test/java/com/metaplex/lib/drivers/identity/KeypairIdentityDriverTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/drivers/identity/KeypairIdentityDriverTests.kt
@@ -1,9 +1,7 @@
 package com.metaplex.lib.drivers.identity
 
-import com.metaplex.lib.SolanaTestData
+import com.metaplex.lib.*
 import com.metaplex.lib.drivers.indenty.KeypairIdentityDriver
-import com.metaplex.lib.mnemonic
-import com.metaplex.lib.publicKey
 import com.metaplex.lib.drivers.solana.SolanaConnectionDriver
 import com.solana.core.Account
 import com.solana.core.DerivationPath
@@ -21,11 +19,12 @@ class KeypairIdentityDriverTests {
     fun testSetUpKeypairIdentityDriverFromMnemonic() {
         // given
         val expectedPublicKey = SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.publicKey
-        val solanaConnection = SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana)
+        val solanaConnection = MetaplexTestUtils.generateConnectionDriver()
+        val account = Account.fromMnemonic(SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.mnemonic,
+            "", DerivationPath.BIP44_M_44H_501H_0H_OH)
 
         // when
-        val keypairIdentityDriver = KeypairIdentityDriver(solanaConnection.solanaRPC,
-            Account.fromMnemonic(SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.mnemonic, "", DerivationPath.BIP44_M_44H_501H_0H_OH))
+        val keypairIdentityDriver = KeypairIdentityDriver(account, solanaConnection)
 
         //then
         Assert.assertEquals(expectedPublicKey, keypairIdentityDriver.publicKey.toBase58())
@@ -34,8 +33,11 @@ class KeypairIdentityDriverTests {
     @Test
     fun testSignTransactionReturnsTrxHash() {
         // given
-        val account = Account.fromMnemonic(SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.mnemonic, "", DerivationPath.BIP44_M_44H_501H_0H_OH)
         val expectedSignedTransaction = "AaHQ/obYLnD6GUFqxDKiiNkw2NYsLt+NZHa8ALB64uM0wpADNVQ5eWhzW38FcxfthDz6zXsJao58y5/fFovSoAABAAEC1J5StK6hI4+ERBMKkBUsHeIzegza3Eb/t7dwtSG4Q9QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJrdSfHQAfBFYiaNQeEg3d9YB3F537Ex4K5dG79qBe0rAQECAAAMAgAAAOgDAAAAAAAA"
+        val account = Account.fromMnemonic(SolanaTestData.TEST_ACCOUNT_MNEMONIC_PAIR.mnemonic,
+            "", DerivationPath.BIP44_M_44H_501H_0H_OH)
+
+        val connectionDriver = MetaplexTestUtils.generateConnectionDriver()
         val instruction = SystemProgram.transfer(account.publicKey, account.publicKey, 1000)
         val transaction = Transaction().apply {
             addInstruction(instruction)
@@ -44,8 +46,7 @@ class KeypairIdentityDriverTests {
 
         // when
         var result: Transaction? = null
-        val keypairIdentityDriver = KeypairIdentityDriver(
-            SolanaConnectionDriver(RPCEndpoint.mainnetBetaSolana).solanaRPC, account)
+        val keypairIdentityDriver = KeypairIdentityDriver(account, connectionDriver)
 
         val lock = CountDownLatch(1)
         keypairIdentityDriver.signTransaction(transaction){

--- a/lib/src/test/java/com/metaplex/lib/modules/candymachine/CandyMachineClientTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/candymachine/CandyMachineClientTests.kt
@@ -9,6 +9,7 @@
 
 package com.metaplex.lib.modules.candymachine
 
+import com.metaplex.lib.MetaplexTestUtils
 import com.metaplex.lib.drivers.indenty.IdentityDriver
 import com.metaplex.lib.drivers.indenty.KeypairIdentityDriver
 import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
@@ -17,6 +18,7 @@ import com.metaplex.lib.drivers.solana.Commitment
 import com.metaplex.lib.drivers.solana.Connection
 import com.metaplex.lib.drivers.solana.SolanaConnectionDriver
 import com.metaplex.lib.drivers.solana.TransactionOptions
+import com.metaplex.lib.generateConnectionDriver
 import com.metaplex.lib.modules.candymachines.CandyMachineClient
 import com.metaplex.lib.modules.candymachines.models.CandyMachine
 import com.metaplex.lib.modules.candymachines.models.CandyMachineItem
@@ -129,7 +131,7 @@ class CandyMachineClientTests {
     fun testFindCandyMachineByAddressReturnsValidCandyMachine() = runTest {
         // given
         val cmAddress = PublicKey("4Add8hdxC44H3DcGfgWTvn2GNBfofk5uu2iatEW9LCYz")
-        val connection = SolanaConnectionDriver(JdkRpcDriver(RPCEndpoint.devnetSolana.url))
+        val connection = MetaplexTestUtils.generateConnectionDriver(RPCEndpoint.devnetSolana.url)
         val client = CandyMachineClient(connection,
             ReadOnlyIdentityDriver(Account().publicKey, connection))
 
@@ -144,11 +146,8 @@ class CandyMachineClientTests {
     @Test
     fun testCandyMachineCreateCreatesValidCandyMachine() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = CandyMachineClient(connection, identityDriver)
 
@@ -167,11 +166,8 @@ class CandyMachineClientTests {
     @Test
     fun testCandyMachineSetCollectionUpdatesCandyMachineCollection() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = CandyMachineClient(connection, identityDriver)
 
@@ -194,11 +190,8 @@ class CandyMachineClientTests {
     @Test
     fun testCandyMachineInsertItemsCanAddItemsToCandyMachine() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = CandyMachineClient(connection, identityDriver)
 
@@ -223,11 +216,8 @@ class CandyMachineClientTests {
     @Test
     fun testCandyMachineInsertItemsSequentiallyAddsItemsToCandyMachine() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = CandyMachineClient(connection, identityDriver)
 
@@ -256,11 +246,8 @@ class CandyMachineClientTests {
     @Test
     fun testCandyMachineMintNftMintsAndReturnsNft() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = CandyMachineClient(connection, identityDriver)
 

--- a/lib/src/test/java/com/metaplex/lib/modules/candymachinev2/CandyMachineV2ClientTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/candymachinev2/CandyMachineV2ClientTests.kt
@@ -7,10 +7,12 @@
 
 package com.metaplex.lib.modules.candymachinev2
 
+import com.metaplex.lib.MetaplexTestUtils
 import com.metaplex.lib.drivers.indenty.KeypairIdentityDriver
 import com.metaplex.lib.drivers.indenty.ReadOnlyIdentityDriver
 import com.metaplex.lib.drivers.rpc.JdkRpcDriver
 import com.metaplex.lib.drivers.solana.*
+import com.metaplex.lib.generateConnectionDriver
 import com.metaplex.lib.modules.candymachines.CandyMachineClient
 import com.metaplex.lib.modules.candymachines.models.CandyMachine
 import com.metaplex.lib.modules.candymachinesv2.CandyMachineV2Client
@@ -33,32 +35,6 @@ class CandyMachineV2ClientTests {
 //    }
 
     //region UNIT
-//    @Test
-//    fun testFindCandyMachineV2ByAddressReturnsCandyMachine() = runTest {
-//        // given
-//        val wallet = Account().publicKey
-//        val candyMachineAddress = Account().publicKey
-//        val expectedCandyMachine = CandyMachineV2(
-//            candyMachineAddress, wallet, wallet, 1, 250.toUShort(), 10
-//        )
-//
-//        val connection = SolanaConnectionDriver(MockRpcDriver().apply {
-//            willReturn(
-//                AccountRequest(candyMachineAddress.toBase58()),
-//                AccountInfo(CandyMachine(wallet, wallet, null, 0.toULong(), CandyMachineData()), false, 0, wallet.toBase58(), 0)
-//            )
-//        })
-//
-//        val client = CandyMachineV2Client(connection, ReadOnlyIdentityDriver(wallet, connection))
-//
-//        // when
-//        val result = client.findByAddress(candyMachineAddress)
-//
-//        // then
-//        Assert.assertTrue(result.isSuccess)
-//        Assert.assertEquals(expectedCandyMachine, result.getOrNull())
-//    }
-
     @Test
     fun testFindCandyMachineV2ByAddressReturnsError() = runTest {
         // given
@@ -115,13 +91,16 @@ class CandyMachineV2ClientTests {
     @Test
     fun testFindCandyMachineV2ByAddressReturnsValidCandyMachine() = runTest {
         // given
-        val cmAddress = PublicKey("Hoj7d8Gtn7L7SUyqCDYqMVrCrgQ59By9GNWw8ppXfoGM")
-        val connection = SolanaConnectionDriver(JdkRpcDriver(RPCEndpoint.devnetSolana.url), transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
-        val client = CandyMachineV2Client(connection,
-            ReadOnlyIdentityDriver(Account().publicKey, connection)
-        )
+        val signer = Account()
+        val connection = MetaplexTestUtils.generateConnectionDriver()
+        val client = CandyMachineV2Client(connection, KeypairIdentityDriver(signer, connection))
 
         // when
+        connection.airdrop(signer.publicKey, 1f)
+        val cmAddress = client.create(1, 250, 10).map {
+            it.address
+        }.getOrThrow()
+
         val candyMachine: CandyMachineV2? = client.findByAddress(cmAddress).getOrNull()
 
         // then
@@ -131,10 +110,8 @@ class CandyMachineV2ClientTests {
     @Test
     fun testCandyMachineCreateCreatesValidCandyMachine() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl), transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val client = CandyMachineV2Client(connection, KeypairIdentityDriver(signer, connection))
 
         // when
@@ -151,10 +128,8 @@ class CandyMachineV2ClientTests {
     @Test
     fun testCandyMachineMintNftMintsAndReturnsNft() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl), transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true))
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val client = CandyMachineV2Client(connection, KeypairIdentityDriver(signer, connection))
 
         // when

--- a/lib/src/test/java/com/metaplex/lib/modules/fungibletokens/operations/FindFungibleTokenByMintOnChainOperationHandlerTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/fungibletokens/operations/FindFungibleTokenByMintOnChainOperationHandlerTests.kt
@@ -9,6 +9,7 @@ import com.metaplex.lib.modules.token.models.FungibleToken
 import com.metaplex.lib.modules.token.operations.FindFungibleTokenByMintOnChainOperationHandler
 import com.metaplex.lib.programs.token_metadata.accounts.MetaplexCreator
 import com.metaplex.lib.programs.token_metadata.accounts.MetaplexTokenStandard
+import com.metaplex.lib.readOnlyMainnetMetaplexInstance
 import com.solana.core.PublicKey
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -17,8 +18,7 @@ import org.junit.Test
 
 class FindFungibleTokenByMintOnChainOperationHandlerTests {
 
-    val metaplex: Metaplex get() =
-        MetaplexTestUtils.generateMetaplexInstance()
+    val metaplex: Metaplex get() = MetaplexTestUtils.readOnlyMainnetMetaplexInstance
 
     @Test
     fun testFindFungibleTokenByMintOnChainOperation() = runTest {

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/NftClientTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/NftClientTests.kt
@@ -7,11 +7,13 @@
 
 package com.metaplex.lib.modules.nfts
 
+import com.metaplex.lib.MetaplexTestUtils
 import com.metaplex.lib.drivers.indenty.KeypairIdentityDriver
 import com.metaplex.lib.drivers.rpc.JdkRpcDriver
 import com.metaplex.lib.drivers.solana.Commitment
 import com.metaplex.lib.drivers.solana.SolanaConnectionDriver
 import com.metaplex.lib.drivers.solana.TransactionOptions
+import com.metaplex.lib.generateConnectionDriver
 import com.metaplex.lib.modules.nfts.models.Metadata
 import com.metaplex.lib.programs.token_metadata.accounts.MetaplexCollectionDetails
 import com.metaplex.mock.driver.rpc.MockErrorRpcDriver
@@ -25,6 +27,7 @@ import java.net.URL
 
 class NftClientTests {
 
+    // UNIT
     @Test
     fun testNftCreateHandlesAndReturnsError() = runTest {
         // given
@@ -49,13 +52,8 @@ class NftClientTests {
     @Test
     fun testNftCreateCreatesValidNft() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(
-            JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true)
-        )
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = NftClient(connection, identityDriver)
 
@@ -79,13 +77,8 @@ class NftClientTests {
     @Test
     fun testNftCreateWithCollectionCreatesValidNft() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(
-            JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true)
-        )
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = NftClient(connection, identityDriver)
 
@@ -113,13 +106,8 @@ class NftClientTests {
     @Test
     fun testNftCreateCollectionCreatesValidCollectionNft() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
-//        val rpcUrl = RPCEndpoint.devnetSolana.url
         val signer = Account()
-        val connection = SolanaConnectionDriver(
-            JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true)
-        )
+        val connection = MetaplexTestUtils.generateConnectionDriver()
         val identityDriver = KeypairIdentityDriver(signer, connection)
         val client = NftClient(connection, identityDriver)
 

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/models/NFTTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/models/NFTTests.kt
@@ -9,6 +9,7 @@ import com.metaplex.lib.generateMetaplexInstance
 import com.metaplex.lib.modules.nfts.operations.FindNftByMintOnChainOperationHandler
 import com.metaplex.lib.modules.token.models.metadata
 import com.metaplex.lib.programs.token_metadata.accounts.MetaplexTokenStandard
+import com.metaplex.lib.readOnlyMainnetMetaplexInstance
 import com.solana.core.PublicKey
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -18,7 +19,7 @@ import org.junit.Test
 class NFTTests {
 
     val metaplex: Metaplex get() =
-        MetaplexTestUtils.generateMetaplexInstance(storageDriver = OkHttpSharedStorageDriver())
+        MetaplexTestUtils.readOnlyMainnetMetaplexInstance
 
     @Test
     fun testsNFTonChain() = runTest {
@@ -81,7 +82,7 @@ class NFTTests {
         // when
         val metadata: JsonMetadata? = FindNftByMintOnChainOperationHandler(metaplex)
             .handle(PublicKey("HG2gLyDxmYGUfNWnvf81bJQj38twnF2aQivpkxficJbn"))
-            .getOrThrow().metadata(metaplex.storage()).getOrNull()
+            .getOrThrow().metadata(OkHttpSharedStorageDriver()).getOrNull()
 
         // then
         Assert.assertNotNull(metadata)  // safe to force unwrap after this check

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftByMintOnChainOperationHandlerTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftByMintOnChainOperationHandlerTests.kt
@@ -6,6 +6,7 @@ import com.metaplex.lib.Metaplex
 import com.metaplex.lib.MetaplexTestUtils
 import com.metaplex.lib.generateMetaplexInstance
 import com.metaplex.lib.modules.nfts.models.NFT
+import com.metaplex.lib.readOnlyMainnetMetaplexInstance
 import com.metaplex.lib.shared.ResultWithCustomError
 import com.metaplex.lib.shared.getOrDefault
 import com.solana.core.PublicKey
@@ -18,7 +19,7 @@ import java.util.concurrent.TimeUnit
 
 class FindNftByMintOnChainOperationHandlerTests {
 
-    val metaplex: Metaplex get() = MetaplexTestUtils.generateMetaplexInstance()
+    val metaplex: Metaplex get() = MetaplexTestUtils.readOnlyMainnetMetaplexInstance
 
     @Test
     fun testFindNftByMintOnChainOperation() = runTest {

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByMintListOnChainOperationHandlerTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByMintListOnChainOperationHandlerTests.kt
@@ -5,6 +5,7 @@ package com.metaplex.lib.modules.nfts.operations
 import com.metaplex.lib.Metaplex
 import com.metaplex.lib.MetaplexTestUtils
 import com.metaplex.lib.generateMetaplexInstance
+import com.metaplex.lib.readOnlyMainnetMetaplexInstance
 import com.solana.core.PublicKey
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
@@ -13,7 +14,7 @@ import org.junit.Test
 
 class FindNftsByMintListOnChainOperationHandlerTests {
 
-    val metaplex: Metaplex get() = MetaplexTestUtils.generateMetaplexInstance()
+    val metaplex: Metaplex get() = MetaplexTestUtils.readOnlyMainnetMetaplexInstance
 
     @Test
     fun testFindNftsByMintListOnChainOperation() = runTest {

--- a/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByOwnerOnChainOperationHandlerTests.kt
+++ b/lib/src/test/java/com/metaplex/lib/modules/nfts/operations/FindNftsByOwnerOnChainOperationHandlerTests.kt
@@ -2,7 +2,7 @@
 
 package com.metaplex.lib.modules.nfts.operations
 
-import com.metaplex.lib.Metaplex
+import com.metaplex.lib.*
 import com.metaplex.lib.drivers.indenty.KeypairIdentityDriver
 import com.metaplex.lib.drivers.rpc.JdkRpcDriver
 import com.metaplex.lib.drivers.solana.Commitment
@@ -24,13 +24,9 @@ class FindNftsByOwnerOnChainOperationHandlerTests {
     @Test
     fun testFindNftsByOwnerOnChainOperation() = runTest {
         // given
-        val rpcUrl = URL("http://127.0.0.1:8899")
         val owner = Account()
-        val connection = SolanaConnectionDriver(JdkRpcDriver(rpcUrl),
-            transactionOptions = TransactionOptions(Commitment.CONFIRMED, skipPreflight = true)
-        )
-        val metaplex = Metaplex(connection,
-            KeypairIdentityDriver(owner, connection), MemoryStorageDriver())
+        val connection = MetaplexTestUtils.generateConnectionDriver()
+        val metaplex = MetaplexTestUtils.generateMetaplexInstance(owner, connection)
 
         // when
         connection.airdrop(owner.publicKey, 1f)


### PR DESCRIPTION
## Description
- Refactor our test suite now that we have the local validator working in CI 

## Work Completed
- moved RPC url to gradle property, which is then loaded into build config
- updated tests to use this build config url (removed the hardcoded local validator URL)
- improved test utils to make it easier to setup a connection driver or metaplex instance for testing (I have more I'd like to do on this front but this is enough for now) 

## Additional Notes
Because the testing rpc URL is now a gradle property, we can easily change the RPC URL used from the command line:
```
./gradlew lib:test -P'testing.rpc.url'=http://the.desired.rpc.url
```

## Testing
- 91/91 unit tests passing locally and on CI