### PR TITLE
Fix Base64 newline/wrapping

### DIFF
--- a/lib/src/main/java/com/metaplex/lib/drivers/solana/Connection.kt
+++ b/lib/src/main/java/com/metaplex/lib/drivers/solana/Connection.kt
@@ -58,7 +58,7 @@ suspend fun Connection.sendTransaction(serializedTransaction: String): Result<St
     get(SendTransactionRequest(serializedTransaction, transactionOptions), String.serializer())
 
 suspend fun Connection.sendTransaction(transaction: Transaction): Result<String> =
-    sendTransaction(Base64.encodeToString(transaction.serialize(), Base64.DEFAULT))
+    sendTransaction(Base64.encodeToString(transaction.serialize(), Base64.NO_WRAP))
 //endregion
 
 // Inlines let us hide the serialization complexity while still providing full control

--- a/lib/src/main/java/com/metaplex/lib/extensions/Transaction+Extensions.kt
+++ b/lib/src/main/java/com/metaplex/lib/extensions/Transaction+Extensions.kt
@@ -58,7 +58,7 @@ suspend fun Transaction.signAndSend(connection: Connection, payer: IdentityDrive
         return Result.failure(it)
     }
 
-    val serializedTxn = Base64.encodeToString(signedTxn.serialize(), Base64.DEFAULT)
+    val serializedTxn = Base64.encodeToString(signedTxn.serialize(), Base64.NO_WRAP)
 
     // sign and send transaction
     return connection.get(
@@ -78,7 +78,7 @@ suspend fun Transaction.signAndSend(connection: Connection, signers: List<Accoun
     sign(signers)
 
     // send transaction
-    return connection.sendTransaction(Base64.encodeToString(serialize(), Base64.DEFAULT))
+    return connection.sendTransaction(Base64.encodeToString(serialize(), Base64.NO_WRAP))
 }
 
 suspend fun Transaction.signSendAndConfirm(

--- a/lib/src/main/java/com/metaplex/lib/serialization/serializers/base64/Base64JsonSerializers.kt
+++ b/lib/src/main/java/com/metaplex/lib/serialization/serializers/base64/Base64JsonSerializers.kt
@@ -33,13 +33,13 @@ object ByteArrayAsBase64JsonArraySerializer: KSerializer<ByteArray> {
 
     override fun serialize(encoder: Encoder, value: ByteArray) =
         encoder.encodeSerializableValue(delegateSerializer, listOf(
-            Base64.encodeToString(value, Base64.DEFAULT), "base64"
+            Base64.encodeToString(value, Base64.NO_WRAP), "base64"
         ))
 
     override fun deserialize(decoder: Decoder): ByteArray {
         decoder.decodeSerializableValue(delegateSerializer).apply {
             if (contains("base64")) first { it != "base64" }.apply {
-                return Base64.decode(this, Base64.DEFAULT)
+                return Base64.decode(this, Base64.NO_WRAP)
             }
             else throw(SerializationException("Not Base64"))
         }


### PR DESCRIPTION
## Description
- Corrects Base64 encoding to use the NO_WRAP option to prevent any newline characters from being placed in the encoded string
- https://github.com/metaplex-foundation/metaplex-android/issues/93

## Work Completed
- Changed all instances of `android.util.Base64.DEFAULT` to `android.util.Base64.NO_WRAP`

## API Changes
- none

## Testing
- ran all unit tests, confirmed no functionality has changed with this update 