### PR TITLE
Add bare bones error handling to network driver

### DIFF
--- a/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
+++ b/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
@@ -42,14 +42,17 @@ class JdkHttpDriver : HttpNetworkDriver {
                 }
 
                 // read response
-                val responseString = inputStream.bufferedReader().use { it.readText() }
+                val response = (inputStream ?: errorStream)?.bufferedReader()?.use {
+                    it.readText()
+                }?.let { responseString -> Result.success(responseString) }
+                    ?: Result.failure(Throwable("No Response"))
 
                 // TODO: should check response code and/or errorStream for errors
 //            println("URL : $url")
 //            println("Response Code : $responseCode")
 //            println("input stream : $responseString")
 
-                continuation.resumeWith(Result.success(responseString))
+                continuation.resumeWith(response)
             }
         }
 }


### PR DESCRIPTION
## Description
- Added barebones error handing to the network driver. 

## Work Completed
- The default network driver (`JdkHttpDriver`) is currently throwing fatal exceptions of the response returns an error in the error stream instead of the input stream
- This change also checks the error stream if the input stream is null

## API Changes
- none

## Testing
- ran all unit tests, verified that this change does not impact any existing calls or error handling 
- confirmed this change works while developing shadow drive integration, confirmed that both successful response and errors are handled by the driver without crashing 