### PR TITLE
Fix HTTP Error Handling added in #100

### DIFF
--- a/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
+++ b/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
@@ -50,7 +50,7 @@ class JdkHttpDriver : HttpNetworkDriver {
                     else -> errorStream.bufferedReader().use { it.readText() }
                 }
 
-                continuation.resumeWith(response)
+                continuation.resumeWith(Result.success(responseString))
             }
         }
 }

--- a/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
+++ b/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
@@ -21,7 +21,7 @@ import kotlin.coroutines.resume
  * @author Funkatronics
  */
 class JdkHttpDriver : HttpNetworkDriver {
-    override suspend fun makeHttpRequest(request: HttpRequest): Result<String> =
+    override suspend fun makeHttpRequest(request: HttpRequest): String =
         suspendCancellableCoroutine { continuation ->
 
             with(URL(request.url).openConnection() as HttpURLConnection) {

--- a/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
+++ b/lib/src/main/java/com/metaplex/lib/drivers/network/JdkHttpDriver.kt
@@ -41,7 +41,7 @@ class JdkHttpDriver : HttpNetworkDriver {
                     outputStream.flush()
                     outputStream.close()
                 }?.onFailure { error ->
-                    continuation.resume(error.message ?: "An unknown error occurred")
+                    continuation.resume(error.toString())
                     return@with
                 }
 


### PR DESCRIPTION
## Description
- Fixed up error handling in JdkHttpDriver

## Work Completed
- made a mistake in my previous pr (#100) that was causing fatal errors to still get through, that is now fixed
- added output error handling (fixes fatal error if the http request is bad) 

## API Changes
- none

## Testing
- ran all unit tests, verified that this change does not impact any existing calls or error handling
- confirmed this change works locally by simulating bad requests